### PR TITLE
Add support for Stencil include tag

### DIFF
--- a/Sources/Swifton/View.swift
+++ b/Sources/Swifton/View.swift
@@ -11,7 +11,13 @@ struct StencilView {
     var context: [String: Any]? 
 
     init(_ path: String, _ context: [String: Any]? = nil) {
-        self.context = context
+        let defaultTemplateLoader = TemplateLoader(paths: [Path(SwiftonConfig.viewsDirectory)])
+        if context != nil {
+            self.context = context
+            self.context!["loader"] = defaultTemplateLoader
+        } else {
+            self.context = ["loader": defaultTemplateLoader]
+        }
 
         var templatePath = path.characters.split{$0 == "/"}.map(String.init)
         let templateName = templatePath.removeLast()


### PR DESCRIPTION
By giving all Stencil views a default context with a `TemplateLoader` we can add global support for the Stencil `{% include ... %}` tag.
This saves us from having to create a template loader on each request or having to modify the ApplicationController like so:

``` swift
import Swifton
import Inquiline
import Stencil
import PathKit

class ApplicationController: Controller {
    override init() { super.init() }

    override func render(template: String, _ context: [String: Any]) -> Response {
        var newContext = context
        newContext["loader"] = TemplateLoader(paths: ["Views"])
        return super.render(template, newContext)
    }

    override func render(template: String) -> Response {
        return super.render(template, ["loader": TemplateLoader(paths: ["Views"]), "page": Path(template).components.first?.lowercaseString])
    }

}
```

Please refer to [Stencil](https://github.com/kylef/Stencil#include) for more information.
